### PR TITLE
Free wasted space

### DIFF
--- a/chirp/src/actions/update.rs
+++ b/chirp/src/actions/update.rs
@@ -4,7 +4,7 @@ use rusqlite::Result;
 use std::error::Error;
 
 use crate::db::{
-    db_content_add, db_log_add, db_source_get_data_web_url_segment,
+    db_content_add, db_content_save_space, db_log_add, db_source_get_data_web_url_segment,
     db_source_retrievals_update_failures, db_source_retrievals_update_success,
     db_sources_retrieve_outdated,
 };
@@ -56,6 +56,8 @@ pub async fn update_single_feed(source: &Source) -> Result<(), Box<dyn Error + S
     db_source_retrievals_update_success(&source.id).unwrap();
 
     println!("finished updating {:?}", source.name);
+
+    db_content_save_space();
 
     Ok(())
 }

--- a/chirp/src/db/content.rs
+++ b/chirp/src/db/content.rs
@@ -81,7 +81,7 @@ pub fn db_map_content_body_query<P: Params>(
 }
 
 const SQL_DELETE_OLD_BODIES: &str =
-    "DELETE FROM content_body WHERE id < (select max(id) from content_body) - 1000";
+    "DELETE FROM content_body WHERE id < (SELECT MAX(id) FROM content_body) - 1000";
 
 pub fn db_content_save_space() -> Result<(), Box<dyn Error>> {
     let conn = db_connect()?;

--- a/chirp/src/db/content.rs
+++ b/chirp/src/db/content.rs
@@ -80,6 +80,18 @@ pub fn db_map_content_body_query<P: Params>(
     Ok(bodies)
 }
 
+const SQL_DELETE_OLD_BODIES: &str =
+    "DELETE FROM content_body WHERE id < (select max(id) from content_body) - 1000";
+
+pub fn db_content_save_space() -> Result<(), Box<dyn Error>> {
+    let conn = db_connect()?;
+    if let Err(e) = conn.execute(&SQL_DELETE_OLD_BODIES, []) {
+        println!("Error deleting old bodies from content_body");
+    }
+
+    Ok(())
+}
+
 pub fn db_map_content_media_query<P: Params>(
     s: &mut Statement,
     p: P,


### PR DESCRIPTION
On every feed update delete the content bodies of all the articles in the database, except for the last 1000.