### PR TITLE
Feature/better titles

### DIFF
--- a/chirp/Cargo.lock
+++ b/chirp/Cargo.lock
@@ -2486,6 +2486,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titles"
 version = "1.0.0"
+source = "git+https://github.com/exquisiteOntologist/PageTitlesSansSourceNames#e6249bc8d3360986901203e768cece0146017710"
 
 [[package]]
 name = "tokio"

--- a/chirp/Cargo.lock
+++ b/chirp/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "rusqlite",
  "scraper",
  "serde",
+ "titles",
  "tokio",
  "typeshare",
  "url",
@@ -2481,6 +2482,10 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "titles"
+version = "1.0.0"
 
 [[package]]
 name = "tokio"

--- a/chirp/Cargo.toml
+++ b/chirp/Cargo.toml
@@ -22,7 +22,7 @@ typeshare = "1"
 # url may conflict with reqwest::Url
 url = "2"
 labels = { git = "https://github.com/exquisiteOntologist/labels.git" }
-titles = { path = "../../../misc-experiments/rust/titles" }
+titles = { git = "https://github.com/exquisiteOntologist/PageTitlesSansSourceNames" }
 
 [lib]
 name = "chirp"

--- a/chirp/Cargo.toml
+++ b/chirp/Cargo.toml
@@ -22,6 +22,7 @@ typeshare = "1"
 # url may conflict with reqwest::Url
 url = "2"
 labels = { git = "https://github.com/exquisiteOntologist/labels.git" }
+titles = { path = "../../../misc-experiments/rust/titles" }
 
 [lib]
 name = "chirp"

--- a/stories/src-tauri/Cargo.lock
+++ b/stories/src-tauri/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "rusqlite",
  "scraper",
  "serde",
+ "titles",
  "tokio",
  "typeshare",
  "url",
@@ -4884,6 +4885,10 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "titles"
+version = "1.0.0"
 
 [[package]]
 name = "tokio"

--- a/stories/src-tauri/Cargo.lock
+++ b/stories/src-tauri/Cargo.lock
@@ -4889,6 +4889,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titles"
 version = "1.0.0"
+source = "git+https://github.com/exquisiteOntologist/PageTitlesSansSourceNames#e6249bc8d3360986901203e768cece0146017710"
 
 [[package]]
 name = "tokio"


### PR DESCRIPTION
This utilises a new crate designed to remove source names from page titles.

Instead of automatically splitting a title on a dash, the new system will find the matching tailing text across all of the titles from a single source.

This means less mangled titles and less source names.